### PR TITLE
Fixed Final Evolution Bug

### DIFF
--- a/lib/pokemondetail.dart
+++ b/lib/pokemondetail.dart
@@ -61,14 +61,19 @@ class PokeDetail extends StatelessWidget {
                       style: TextStyle(fontWeight: FontWeight.bold)),
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: pokemon.nextEvolution
-                        .map((n) => FilterChip(
-                            backgroundColor: Colors.green,
-                            label: Text(n.name,
-                                style: TextStyle(color: Colors.white)),
-                            onSelected: (b) {}))
-                        .toList(),
-                  ),
+                    children: pokemon.nextEvolution == null
+                        ? <Widget>[Text("This is the final form")]
+                        : pokemon.nextEvolution
+                            .map((n) => FilterChip(
+                                  backgroundColor: Colors.green,
+                                  label: Text(
+                                    n.name,
+                                    style: TextStyle(color: Colors.white),
+                                  ),
+                                  onSelected: (b) {},
+                                ))
+                            .toList(),
+                  )
                 ],
               ),
             ),


### PR DESCRIPTION
The app crashed when opening the details about a pokemon who was already in the final stage. Added a conditional statement so that the section is displayed only when the pokemon is not in final form.